### PR TITLE
Use LLJzip for faster scanning

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,6 +48,8 @@ dependencies {
 
     "shadowImplement"("com.github.Col-E:CAFED00D:1.10.2")
     "shadowImplement"("org.slf4j:slf4j-jdk14:2.0.7")
+
+    "shadowImplement"(group = "software.coley", name = "lljzip", version = "1.4.0")
     //shadow("org.slf4j:slf4j:2.0.7")
 
 

--- a/src/main/kotlin/dev/kosmx/needle/CheckWrapper.kt
+++ b/src/main/kotlin/dev/kosmx/needle/CheckWrapper.kt
@@ -8,6 +8,8 @@ import dev.kosmx.needle.database.Database
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.ReceiveChannel
+import software.coley.llzip.ZipIO
+import software.coley.llzip.format.model.ZipArchive
 import java.io.File
 import java.io.InputStream
 import java.nio.file.Path
@@ -57,8 +59,8 @@ object CheckWrapper {
     fun checkJar(path: Path): Set<JarCheckResult> {
         require(initialized) { "Cannot run check before initialization is complete" }
 
-        path.toFile().inputStream().use {
-            return checkJar(it)
+        ZipIO.readJvm(path).use { jar ->
+            return checkJar(jar)
         }
     }
 
@@ -66,12 +68,10 @@ object CheckWrapper {
      * Check jar input stream, can be used from memory files or web API backend
      */
     @JvmStatic
-    fun checkJar(inputStream: InputStream): Set<JarCheckResult> {
+    fun checkJar(zipArchive: ZipArchive): Set<JarCheckResult> {
         require(initialized) { "Cannot run check before initialization is complete" }
 
-        JarInputStream(inputStream).use {
-            return JarChecker.checkJar(it)
-        }
+        return JarChecker.checkJar(zipArchive)
     }
 
     /**

--- a/src/main/kotlin/dev/kosmx/needle/CliRun.kt
+++ b/src/main/kotlin/dev/kosmx/needle/CliRun.kt
@@ -6,7 +6,9 @@ import kotlinx.cli.ArgParser
 import kotlinx.cli.ArgType
 import kotlinx.cli.default
 import kotlinx.cli.required
+import kotlinx.coroutines.runBlocking
 import kotlin.io.path.Path
+import kotlin.jvm.internal.Ref.IntRef
 import kotlin.time.ExperimentalTime
 import kotlin.time.measureTime
 
@@ -34,14 +36,15 @@ fun main(args: Array<String>) {
     } else {
 
         measureTime {
-            val foundStuff = CheckWrapper.checkPathBlocking(path, threads)
+            val count = IntRef()
+            val foundStuff = runBlocking { CheckWrapper.checkPath(path, threads, scannedCount = count) }
 
 
             foundStuff.forEach { (file, founding) ->
                 println("$file matches ${founding.map { it.getMessage() }}")
             }
 
-            println("Finished running, found ${foundStuff.size}")
+            println("Finished running, checked ${count.element}, found ${foundStuff.size}")
         }.let { println("Malware checking done in ${it.inWholeMilliseconds} ms") }
     }
 

--- a/src/main/kotlin/dev/kosmx/needle/core/AssetChecker.kt
+++ b/src/main/kotlin/dev/kosmx/needle/core/AssetChecker.kt
@@ -1,6 +1,7 @@
 package dev.kosmx.needle.core
 
 import dev.kosmx.needle.database.AssetMatch
+import software.coley.llzip.format.model.LocalFileHeader
 import java.util.jar.JarEntry
 
 /**
@@ -10,7 +11,7 @@ object AssetChecker {
 
     private lateinit var assets: List<AssetMatch>
 
-    fun checkAsset(bytes: Lazy<ByteArray>, asset: JarEntry): Set<JarCheckResult> {
+    fun checkAsset(bytes: Lazy<ByteArray>, asset: LocalFileHeader): Set<JarCheckResult> {
 
         val result = mutableSetOf<JarCheckResult>()
 

--- a/src/main/kotlin/dev/kosmx/needle/core/JarChecker.kt
+++ b/src/main/kotlin/dev/kosmx/needle/core/JarChecker.kt
@@ -6,6 +6,12 @@ import me.coley.cafedude.io.ClassFileReader
 import me.coley.cafedude.io.ClassFileWriter
 import me.coley.cafedude.transform.IllegalStrippingTransformer
 import org.objectweb.asm.ClassReader
+import software.coley.llzip.ZipIO
+import software.coley.llzip.format.compression.ZipCompressions
+import software.coley.llzip.format.model.LocalFileHeader
+import software.coley.llzip.format.model.ZipArchive
+import software.coley.llzip.util.ByteData
+import software.coley.llzip.util.ByteDataUtil
 import java.io.BufferedInputStream
 import java.io.ByteArrayInputStream
 import java.io.File
@@ -18,52 +24,58 @@ object JarChecker {
 
     fun checkJar(file: File): Set<JarCheckResult> {
         try {
-            JarInputStream(BufferedInputStream(file.inputStream())).use {
-                return checkJar(it)
+            ZipIO.readJvm(file.toPath()).use { jar ->
+                return CheckWrapper.checkJar(jar)
             }
         } catch (t: Throwable) {
-            log { "Failed to open $file" }
+            log {
+                t.printStackTrace()
+                "Failed to open $file"
+            }
         }
         return setOf()
     }
 
-    fun checkJar(jar: JarInputStream): Set<JarCheckResult> {
+    fun checkJar(jar: ZipArchive): Set<JarCheckResult> {
         val results = mutableSetOf<JarCheckResult>()
-        for ((jarEntry, bytes) in jar) {
-            if (jarEntry.name.endsWith(".class")) {
-                try {
-                    results += checkClassFile(bytes.value, jarEntry)
-                    continue
-                } catch (e: IOException) {
-                    //results += JarCheckMatch(MatchType.POTENTIAL, "Illegal .class file: ${jarEntry.name}")
-                }
-            } else if (jarEntry.name.endsWith(".jar")) {
-                try {
-                    JarInputStream(ByteArrayInputStream(bytes.value)).use { jarStream ->
-                        results += checkJar(jarStream) // check nested jars recursively
+        for ((jarEntry, byteData) in jar) {
+            byteData.let classEntry@{_ ->
+                val bytes = lazy { ByteDataUtil.toByteArray(byteData)!! }
+                if (jarEntry.fileNameAsString.endsWith(".class") || jarEntry.fileNameAsString.endsWith(".class/")) {
+                    try {
+                        results += checkClassFile(bytes.value, jarEntry)
+                        return@classEntry
+                    } catch (e: IOException) {
+                        //results += JarCheckMatch(MatchType.POTENTIAL, "Illegal .class file: ${jarEntry.name}")
                     }
-                    continue
+                } else if (jarEntry.fileNameAsString.endsWith(".jar")) {
+                    try {
+
+                        ZipIO.readJvm(byteData).use { jar ->
+                            results += CheckWrapper.checkJar(jar)
+                        }
+                        return@classEntry
+                    } catch (t: Throwable) {
+                        results += JarCheckMatch(MatchType.INFO, "Failed to open nested jar: ${t.message}")
+                        log(LogLevel.Info) {
+                            t.printStackTrace()
+                            t.message ?: ""
+                        }
+                    }
+                }
+
+                try {
+                    results += AssetChecker.checkAsset(bytes, jarEntry)
                 } catch (t: Throwable) {
-                    results += JarCheckMatch(MatchType.INFO, "Failed to open nested jar: ${t.message}")
-                    log(LogLevel.Info) {
-                        t.printStackTrace()
-                        t.message ?: ""
-                    }
+                    results += JarCheckMatch(MatchType.INFO, "Asset checker failed: ${t.message}")
                 }
             }
-
-            try {
-                results += AssetChecker.checkAsset(bytes, jarEntry)
-            } catch (t: Throwable) {
-                results += JarCheckMatch(MatchType.INFO, "Asset checker failed: ${t.message}")
-            }
-
         }
 
         return results
     }
 
-    private fun checkClassFile(bytes: ByteArray, jarEntry: JarEntry): Set<JarCheckResult> {
+    private fun checkClassFile(bytes: ByteArray, jarEntry: LocalFileHeader): Set<JarCheckResult> {
         try {
             val classReader = ClassReader(bytes)
 
@@ -95,3 +107,8 @@ fun JarInputStream.asSequence() = sequence<Pair<JarEntry, Lazy<ByteArray>>> {
 }
 
 operator fun JarInputStream.iterator(): Iterator<Pair<JarEntry, Lazy<ByteArray>>> = this.asSequence().iterator()
+
+fun ZipArchive.asSequence() = localFiles.asSequence().map { it to ZipCompressions.decompress(it) }
+
+operator fun ZipArchive.iterator(): Iterator<Pair<LocalFileHeader, ByteData>> = this.asSequence().iterator()
+

--- a/src/main/kotlin/dev/kosmx/needle/database/AssetMatch.kt
+++ b/src/main/kotlin/dev/kosmx/needle/database/AssetMatch.kt
@@ -1,8 +1,9 @@
 package dev.kosmx.needle.database
 
 import org.objectweb.asm.tree.AbstractInsnNode
+import software.coley.llzip.format.model.LocalFileHeader
 import java.util.jar.JarEntry
 
 interface AssetMatch : Match {
-    fun match(data: Lazy<ByteArray>, jarEntry: JarEntry): Boolean
+    fun match(data: Lazy<ByteArray>, jarEntry: LocalFileHeader): Boolean
 }

--- a/src/main/kotlin/dev/kosmx/needle/database/FileParser.kt
+++ b/src/main/kotlin/dev/kosmx/needle/database/FileParser.kt
@@ -12,6 +12,7 @@ import kotlinx.serialization.json.Json
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.tree.AbstractInsnNode
 import org.objectweb.asm.tree.ClassNode
+import software.coley.llzip.format.model.LocalFileHeader
 import java.nio.file.Path
 import java.util.*
 import java.util.jar.JarEntry
@@ -98,8 +99,8 @@ data class Info(
 data class Asset(val name: String, val threat: MatchType = MatchType.POTENTIAL, val data: String? = null, val fileName: String? = null) :
     AssetMatch {
     private val bytes by lazy { data?.let { Base64.getDecoder().decode(it) } }
-    override fun match(data: Lazy<ByteArray>, jarEntry: JarEntry): Boolean {
-        if (fileName != null && jarEntry.name != name) return false
+    override fun match(data: Lazy<ByteArray>, jarEntry: LocalFileHeader): Boolean {
+        if (fileName != null && jarEntry.fileNameAsString != name) return false
 
         return if (bytes != null) {
             data.value.contentEquals(bytes)


### PR DESCRIPTION
- [x] reimplement types
- [x] reliable testrun, waiting for a bugfix in LLJzip
- [ ] actually faster overall run without cache